### PR TITLE
Fix deployment compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,29 @@ This project includes tools useful for viewing catalogs of Geotrellis
 data stored on S3. It is currently compatible with geotrellis metadata
 from the 0.10 release or better.
 
+## Dependencies
+
+- [npm](https://www.npmjs.com/)
+- [webpack](https://webpack.github.io/)
+- [docker](https://www.docker.com/)
+- [docker-compose](https://docs.docker.com/compose/overview/)
+
+All Scala dependencies (geotrellis, spark, etc.) are pulled through `sbt`
+in the usual way.
+
+It is also assumed that you have a valid S3 bucket with ingested Geotrellis data.
+
+## Building
+
+Run `make build` in the project directory. This will compile all project code
+and assets, and create the docker images used to run the client.
+
 ## Usage
 
-Add the S3 bucket and s3 key fields to `docker-compose.yml` and
+Complete the `S3_BUCKET` and `S3_KEY` fields in `docker-compose.yml` and
 call `docker-compose up`. At this point, you should be able to visit
-localhost on port 8090.
+localhost on port 8090 to access the viewing client.
 
-If you're having trouble with AWS permissions, check to see that your
-credentials are stored in the standard location (`~/.aws`).
+**Note**: If you're having trouble with AWS permissions, check to see
+that your credentials are stored in the standard location (`~/.aws`).
 

--- a/deploy/client_entry.sh
+++ b/deploy/client_entry.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-echo "IP ${GEOTRELLISADMIN_ADMINSERVER_1_PORT_8080_TCP_ADDR}"
-echo "PORT ${GEOTRELLISADMIN_ADMINSERVER_1_PORT_8080_TCP_PORT}"
-
-sed -i.bak "s/{GT-ADMIN-ADDR}/${GEOTRELLISADMIN_ADMINSERVER_1_PORT_8080_TCP_ADDR}/g" /etc/nginx/nginx.conf
-sed -i.bak "s/{GT-ADMIN-PORT}/${GEOTRELLISADMIN_ADMINSERVER_1_PORT_8080_TCP_PORT}/g" /etc/nginx/nginx.conf
+echo "Starting nginx..."
 
 nginx -g "daemon off;"
 "$@"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -26,7 +26,7 @@ http {
     listen       8090;
 
     location /gt {
-      proxy_pass http://{GT-ADMIN-ADDR}:{GT-ADMIN-PORT};
+      proxy_pass http://adminserver:8080;
     }
 
     location / {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
-#version: '1'
-adminclient:
-  image: moradology/geotrellis-admin-client:latest
-  ports:
-    - "8090:8090"
-  links:
-    - adminserver:geotrellis.admin.server
-adminserver:
-  image: moradology/geotrellis-admin-server:latest
-  environment: # Set your S3 bucket and S3 key here
-    - S3_BUCKET=
-    - S3_KEY=
-  ports:
-    - "8080:8080"
-  volumes:
-    - ~/.aws:/root/.aws
+version: '2'
+services:
+  adminclient:
+    image: moradology/geotrellis-admin-client:latest
+    ports:
+      - "8090:8090"
+    links:
+      - adminserver:geotrellis.admin.server
+  adminserver:
+    image: moradology/geotrellis-admin-server:latest
+    environment: # Set your S3 bucket and S3 key here
+      - S3_BUCKET=
+      - S3_KEY=
+    ports:
+      - "8080:8080"
+    volumes:
+      - ~/.aws:/root/.aws
 


### PR DESCRIPTION
Avoid using linked environment variables, and instead use the service hostnames to refer to each other.

Also updated the README.
